### PR TITLE
Device token posts to server

### DIFF
--- a/Example/ManagedStatsOC.xcodeproj/project.pbxproj
+++ b/Example/ManagedStatsOC.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		4D4286F31BAB0C0C00AFD8E8 /* MSSettingsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4286F21BAB0C0C00AFD8E8 /* MSSettingsManager.m */; };
-		4D4286F61BAB0DD000AFD8E8 /* MSApiClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4286F51BAB0DD000AFD8E8 /* MSApiClient.m */; };
 		4D4286F91BAB194800AFD8E8 /* MSDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4286F81BAB194800AFD8E8 /* MSDataManager.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
@@ -47,8 +46,6 @@
 		4855496C61068B9FED288401 /* Pods-ManagedStatsOC_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ManagedStatsOC_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ManagedStatsOC_Tests/Pods-ManagedStatsOC_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		4D4286F11BAB0C0C00AFD8E8 /* MSSettingsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSSettingsManager.h; sourceTree = "<group>"; };
 		4D4286F21BAB0C0C00AFD8E8 /* MSSettingsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSSettingsManager.m; sourceTree = "<group>"; };
-		4D4286F41BAB0DD000AFD8E8 /* MSApiClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSApiClient.h; sourceTree = "<group>"; };
-		4D4286F51BAB0DD000AFD8E8 /* MSApiClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSApiClient.m; sourceTree = "<group>"; };
 		4D4286F71BAB194800AFD8E8 /* MSDataManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSDataManager.h; sourceTree = "<group>"; };
 		4D4286F81BAB194800AFD8E8 /* MSDataManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDataManager.m; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* ManagedStatsOC_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ManagedStatsOC_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -111,8 +108,6 @@
 				4D4286F21BAB0C0C00AFD8E8 /* MSSettingsManager.m */,
 				4D4286F71BAB194800AFD8E8 /* MSDataManager.h */,
 				4D4286F81BAB194800AFD8E8 /* MSDataManager.m */,
-				4D4286F41BAB0DD000AFD8E8 /* MSApiClient.h */,
-				4D4286F51BAB0DD000AFD8E8 /* MSApiClient.m */,
 			);
 			name = Managers;
 			sourceTree = "<group>";
@@ -424,7 +419,6 @@
 				6003F5A7195388D20070C39A /* MAViewController.m in Sources */,
 				4D4286F31BAB0C0C00AFD8E8 /* MSSettingsManager.m in Sources */,
 				4D4286F91BAB194800AFD8E8 /* MSDataManager.m in Sources */,
-				4D4286F61BAB0DD000AFD8E8 /* MSApiClient.m in Sources */,
 				6003F59A195388D20070C39A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/ManagedStatsOC.xcodeproj/project.pbxproj
+++ b/Example/ManagedStatsOC.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D4286F31BAB0C0C00AFD8E8 /* MSSettingsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4286F21BAB0C0C00AFD8E8 /* MSSettingsManager.m */; };
+		4D4286F61BAB0DD000AFD8E8 /* MSApiClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4286F51BAB0DD000AFD8E8 /* MSApiClient.m */; };
+		4D4286F91BAB194800AFD8E8 /* MSDataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D4286F81BAB194800AFD8E8 /* MSDataManager.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -42,6 +45,12 @@
 		1F51595ED0DC3EF3CAAE9CE7 /* Pods-ManagedStatsOC_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ManagedStatsOC_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ManagedStatsOC_Example/Pods-ManagedStatsOC_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		45C1856419DF3495A8247A48 /* Pods_ManagedStatsOC_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ManagedStatsOC_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4855496C61068B9FED288401 /* Pods-ManagedStatsOC_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ManagedStatsOC_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ManagedStatsOC_Tests/Pods-ManagedStatsOC_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		4D4286F11BAB0C0C00AFD8E8 /* MSSettingsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSSettingsManager.h; sourceTree = "<group>"; };
+		4D4286F21BAB0C0C00AFD8E8 /* MSSettingsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSSettingsManager.m; sourceTree = "<group>"; };
+		4D4286F41BAB0DD000AFD8E8 /* MSApiClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSApiClient.h; sourceTree = "<group>"; };
+		4D4286F51BAB0DD000AFD8E8 /* MSApiClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSApiClient.m; sourceTree = "<group>"; };
+		4D4286F71BAB194800AFD8E8 /* MSDataManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSDataManager.h; sourceTree = "<group>"; };
+		4D4286F81BAB194800AFD8E8 /* MSDataManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDataManager.m; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* ManagedStatsOC_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ManagedStatsOC_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -95,6 +104,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4D4286F01BAB0BC100AFD8E8 /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				4D4286F11BAB0C0C00AFD8E8 /* MSSettingsManager.h */,
+				4D4286F21BAB0C0C00AFD8E8 /* MSSettingsManager.m */,
+				4D4286F71BAB194800AFD8E8 /* MSDataManager.h */,
+				4D4286F81BAB194800AFD8E8 /* MSDataManager.m */,
+				4D4286F41BAB0DD000AFD8E8 /* MSApiClient.h */,
+				4D4286F51BAB0DD000AFD8E8 /* MSApiClient.m */,
+			);
+			name = Managers;
+			sourceTree = "<group>";
+		};
 		6003F581195388D10070C39A = {
 			isa = PBXGroup;
 			children = (
@@ -138,6 +160,7 @@
 				6003F5A5195388D20070C39A /* MAViewController.h */,
 				6003F5A6195388D20070C39A /* MAViewController.m */,
 				6003F5A8195388D20070C39A /* Images.xcassets */,
+				4D4286F01BAB0BC100AFD8E8 /* Managers */,
 				6003F594195388D20070C39A /* Supporting Files */,
 				C1B739F01BA782AD001BE171 /* disclaimer.html */,
 			);
@@ -250,6 +273,9 @@
 				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = "Bob Pascazio";
 				TargetAttributes = {
+					6003F589195388D20070C39A = {
+						DevelopmentTeam = 2NJB457542;
+					};
 					6003F5AD195388D20070C39A = {
 						TestTargetID = 6003F589195388D20070C39A;
 					};
@@ -396,6 +422,9 @@
 			files = (
 				6003F59E195388D20070C39A /* MAAppDelegate.m in Sources */,
 				6003F5A7195388D20070C39A /* MAViewController.m in Sources */,
+				4D4286F31BAB0C0C00AFD8E8 /* MSSettingsManager.m in Sources */,
+				4D4286F91BAB194800AFD8E8 /* MSDataManager.m in Sources */,
+				4D4286F61BAB0DD000AFD8E8 /* MSApiClient.m in Sources */,
 				6003F59A195388D20070C39A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -516,12 +545,15 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ManagedStatsOC/ManagedStatsOC-Prefix.pch";
 				INFOPLIST_FILE = "ManagedStatsOC/ManagedStatsOC-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -532,12 +564,15 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ManagedStatsOC/ManagedStatsOC-Prefix.pch";
 				INFOPLIST_FILE = "ManagedStatsOC/ManagedStatsOC-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Example/ManagedStatsOC/MAAppDelegate.h
+++ b/Example/ManagedStatsOC/MAAppDelegate.h
@@ -7,6 +7,7 @@
 //
 
 @import UIKit;
+#import "ManagedStatsOC.h"
 
 @interface MAAppDelegate : UIResponder <UIApplicationDelegate>
 

--- a/Example/ManagedStatsOC/MAAppDelegate.m
+++ b/Example/ManagedStatsOC/MAAppDelegate.m
@@ -84,23 +84,18 @@
 - (void)application:(UIApplication*)application didReceiveRemoteNotification:(NSDictionary*)userInfo
 {
     NSLog(@"Received notification: %@", userInfo);
-//    NSString *alertValue = [[userInfo valueForKey:@"aps"] valueForKey:@"alert"];
+    NSString *alertValue = [[userInfo valueForKey:@"aps"] valueForKey:@"alert"];
     
-//    if (application.applicationState == UIApplicationStateActive)
-//    {
-//        [TKAlertView showWithMessage:alertValue];
-//        [[TKDataManager sharedManager].audioPlayer play];
-//    }else {
-//        if (dm().userAuthenticated) {
-//            dm().receivedNotification = YES;
-//            [self switchToHome];
-//            [TKAlertView showWithMessage:alertValue];
-//        }else {
-//            [self switchToLogin];
-//        }
-//    }
-    
-    [[UIApplication sharedApplication] cancelAllLocalNotifications];
+    if (application.applicationState == UIApplicationStateActive)
+    {
+        UILocalNotification *localNotification = [[UILocalNotification alloc] init];
+        localNotification.userInfo = userInfo;
+        localNotification.soundName = UILocalNotificationDefaultSoundName;
+        localNotification.alertBody = alertValue;
+        localNotification.fireDate = [NSDate date];
+        [[UIApplication sharedApplication] scheduleLocalNotification:localNotification];
+    }
+
     [UIApplication sharedApplication].applicationIconBadgeNumber = 0;
 }
 

--- a/Example/ManagedStatsOC/MAAppDelegate.m
+++ b/Example/ManagedStatsOC/MAAppDelegate.m
@@ -7,12 +7,21 @@
 //
 
 #import "MAAppDelegate.h"
+#import "MSSettingsManager.h"
 
 @implementation MAAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    // Override point for customization after application launch.
+    if ([application respondsToSelector:@selector(registerUserNotificationSettings:)]) {
+        UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:(UIUserNotificationTypeAlert
+                                                                                             | UIUserNotificationTypeBadge
+                                                                                             | UIUserNotificationTypeSound) categories:nil];
+        [application registerUserNotificationSettings:settings];
+    }
+    
+    [[UIApplication sharedApplication] setApplicationIconBadgeNumber: 0];
+   
     return YES;
 }
 
@@ -42,5 +51,58 @@
 {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
+
+#pragma mark - Notifications
+- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+{
+    //register to receive notifications
+    [application registerForRemoteNotifications];
+}
+
+- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo completionHandler:(void(^)())completionHandler
+{
+    //handle the actions
+    if ([identifier isEqualToString:@"declineAction"]){
+    }
+    else if ([identifier isEqualToString:@"answerAction"]){
+    }
+}
+
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+{
+    NSLog(@"device token : %@", deviceToken);
+    ManagedStats* ms = [[ManagedStats alloc] initWithAppKey:@"DhaMufqfSc0pYswzoW_qUg" apiKey:@"KF4y0GeMVzIMMKMBJE6TpA"];
+    [ms sendDeviceTokenToServer:deviceToken ];
+}
+
+
+- (void)application:(UIApplication*)application didFailToRegisterForRemoteNotificationsWithError:(NSError*)error
+{
+    NSLog(@"Failed to get token, error: %@", error);
+}
+
+- (void)application:(UIApplication*)application didReceiveRemoteNotification:(NSDictionary*)userInfo
+{
+    NSLog(@"Received notification: %@", userInfo);
+//    NSString *alertValue = [[userInfo valueForKey:@"aps"] valueForKey:@"alert"];
+    
+//    if (application.applicationState == UIApplicationStateActive)
+//    {
+//        [TKAlertView showWithMessage:alertValue];
+//        [[TKDataManager sharedManager].audioPlayer play];
+//    }else {
+//        if (dm().userAuthenticated) {
+//            dm().receivedNotification = YES;
+//            [self switchToHome];
+//            [TKAlertView showWithMessage:alertValue];
+//        }else {
+//            [self switchToLogin];
+//        }
+//    }
+    
+    [[UIApplication sharedApplication] cancelAllLocalNotifications];
+    [UIApplication sharedApplication].applicationIconBadgeNumber = 0;
+}
+
 
 @end

--- a/Example/ManagedStatsOC/MSApiClient.h
+++ b/Example/ManagedStatsOC/MSApiClient.h
@@ -1,0 +1,22 @@
+//
+//  MSApiClient.h
+//  ManagedStatsOC
+//
+//  Created by Jacqueline Caraballo on 9/17/15.
+//  Copyright (c) 2015 Bob Pascazio. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+//typedef void(^MSAPIClientCompletionBlock)(id response, NSError *error);
+//
+//@interface MSApiClient : AFHTTPSessionManager
+//
+//@property (nonatomic, strong) NSString *authToken;
+//+ (instancetype)sharedManager;
+//
+//- (void)authenticateUserWithLoginInfo:(NSDictionary *)loginInfo  completion:(MSAPIClientCompletionBlock)completion;
+//- (void)createUserWithLoginInfo:(NSDictionary *)loginInfo completion:(MSAPIClientCompletionBlock)completion;
+//
+//@end

--- a/Example/ManagedStatsOC/MSApiClient.m
+++ b/Example/ManagedStatsOC/MSApiClient.m
@@ -1,0 +1,87 @@
+//
+//  MSApiClient.m
+//  ManagedStatsOC
+//
+//  Created by Jacqueline Caraballo on 9/17/15.
+//  Copyright (c) 2015 Bob Pascazio. All rights reserved.
+//
+
+#import "MSApiClient.h"
+#import "MSSettingsManager.h"
+
+#if DEBUG
+static NSString *kBaseURL = @"http://portal.managedapps.co/";
+#else
+static NSString *kBaseURL = @"http://portal.managedapps.co/";
+#endif
+
+// or http://portal.managedapps.co/v1
+
+@implementation MSApiClient : NSObject 
+
+//+ (instancetype)sharedManager
+//{
+//    static MSApiClient *_sharedManager = nil;
+//    static dispatch_once_t onceToken;
+//    dispatch_once(&onceToken, ^{
+//        _sharedManager = [[self alloc] initWithBaseURL:[NSURL URLWithString:kBaseURL]];
+//    });
+//    
+//    return _sharedManager;
+//}
+
+#pragma mark - services
+
+//- (void)authenticateUserWithLoginInfo:(NSDictionary *)loginInfo completion:(MSAPIClientCompletionBlock)completion
+//{
+//    NSMutableDictionary *params = [[MSSettingsManager sharedManager] deviceInfo].mutableCopy;
+//    [loginInfo setValue:[params objectForKey:@"app_version"] forKey:@"app_version"];
+//    [loginInfo setValue:[params objectForKey:@"device_os"] forKey:@"device_os"];
+//    [loginInfo setValue:[params objectForKey:@"device_token"] forKey:@"device_token"];
+//    
+//    [params setObject:loginInfo forKey:@"user"];
+//    NSMutableDictionary *paramsDict = [[NSMutableDictionary alloc] init];
+//    [paramsDict setObject:loginInfo forKey:@"user"];
+//    
+//    NSParameterAssert(completion);
+//    [self
+//     POST:[NSString stringWithFormat:@"login"]
+//     parameters:paramsDict
+//     success:^(NSURLSessionDataTask *task, id responseObject) {
+//         completion(responseObject, nil);
+//         NSLog(@"responseObject = %@", responseObject);
+//         
+//     }
+//     failure:^(NSURLSessionDataTask *task, NSError *error) {
+//         completion(nil, error);
+//     }];
+//}
+
+//- (void)createUserWithLoginInfo:(NSDictionary *)loginInfo completion:(MSAPIClientCompletionBlock)completion
+//{
+//    NSMutableDictionary *params = [[MSSettingsManager sharedManager] deviceInfo].mutableCopy;
+//    
+//    [params setObject:[loginInfo objectForKey:@"latitude"] forKey:@"latitude"];
+//    [params setObject:[loginInfo objectForKey:@"longitude"] forKey:@"longitude"];
+//    
+//    [loginInfo setValue:[params objectForKey:@"app_version"] forKey:@"app_version"];
+//    [loginInfo setValue:[params objectForKey:@"device_os"] forKey:@"device_os"];
+//    [loginInfo setValue:[params objectForKey:@"device_token"] forKey:@"device_token"];
+//    
+//    [params setObject:loginInfo forKey:@"user"];
+//    NSMutableDictionary *paramsDict = [[NSMutableDictionary alloc] init];
+//    [paramsDict setObject:loginInfo forKey:@"user"];
+//    
+//    NSParameterAssert(completion);
+//    [self
+//     POST: [NSString stringWithFormat:@"users"]
+//     parameters:params
+//     success:^(NSURLSessionDataTask *task, id responseObject) {
+//         completion(responseObject, nil);
+//     }
+//     failure:^(NSURLSessionDataTask *task, NSError *error) {
+//         completion(nil, error);
+//     }];
+//}
+
+@end

--- a/Example/ManagedStatsOC/MSDataManager.h
+++ b/Example/ManagedStatsOC/MSDataManager.h
@@ -1,0 +1,19 @@
+//
+//  MSDataManager.h
+//  ManagedStatsOC
+//
+//  Created by Jacqueline Caraballo on 9/17/15.
+//  Copyright (c) 2015 Bob Pascazio. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MSDataManager : NSObject
+
+@property (nonatomic, readwrite) BOOL receivedNotification;
+//@property (nonatomic, strong) NSString *appKey;
+//@property (nonatomic, strong) NSString *apiKey;
+
++ (instancetype)sharedManager;
+-(void)postDeviceToken:(NSData *)devToken appKey:(NSString *)appKey apiKey:(NSString *)apiKey;
+@end

--- a/Example/ManagedStatsOC/MSDataManager.m
+++ b/Example/ManagedStatsOC/MSDataManager.m
@@ -1,0 +1,39 @@
+//
+//  MSDataManager.m
+//  ManagedStatsOC
+//
+//  Created by Jacqueline Caraballo on 9/17/15.
+//  Copyright (c) 2015 Bob Pascazio. All rights reserved.
+//
+
+#import "MSDataManager.h"
+#import <AFNetworking/AFNetworking.h>
+
+@implementation MSDataManager
+
+#pragma mark - init
+
++ (instancetype)sharedManager
+{
+    static MSDataManager *_sharedManager = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _sharedManager = [[self alloc] init];
+    });
+    
+    return _sharedManager;
+}
+
+
+/*
+-(void)postDeviceToken:(NSData *)devToken appKey:(NSString *)appKey apiKey:(NSString *)apiKey{
+    AFHTTPRequestOperationManager *manager = [AFHTTPRequestOperationManager manager];
+    NSDictionary *parameters = @{@"deviceToken": devToken, @"appKey": appKey, @"apiKey": apiKey};
+    [manager POST:@"http://example.com/resources.json" parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        NSLog(@"JSON: %@", responseObject);
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        NSLog(@"Error: %@", error);
+    }];
+}
+*/
+@end

--- a/Example/ManagedStatsOC/MSSettingsManager.h
+++ b/Example/ManagedStatsOC/MSSettingsManager.h
@@ -14,6 +14,7 @@
 
 + (instancetype)sharedManager;
 
+- (void)registerDefaults;
 - (NSDictionary *)deviceInfo;
 
 @end

--- a/Example/ManagedStatsOC/MSSettingsManager.h
+++ b/Example/ManagedStatsOC/MSSettingsManager.h
@@ -1,0 +1,19 @@
+//
+//  MSSettingsManager.h
+//  ManagedStatsOC
+//
+//  Created by Jacqueline Caraballo on 9/17/15.
+//  Copyright (c) 2015 Bob Pascazio. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MSSettingsManager : NSObject
+
+@property (nonatomic, strong) NSData *deviceToken;
+
++ (instancetype)sharedManager;
+
+- (NSDictionary *)deviceInfo;
+
+@end

--- a/Example/ManagedStatsOC/MSSettingsManager.m
+++ b/Example/ManagedStatsOC/MSSettingsManager.m
@@ -1,0 +1,68 @@
+//
+//  MSSettingsManager.m
+//  ManagedStatsOC
+//
+//  Created by Jacqueline Caraballo on 9/17/15.
+//  Copyright (c) 2015 Bob Pascazio. All rights reserved.
+//
+
+#import "MSSettingsManager.h"
+
+// to be replaced with saved user profile
+#define UserDefaultsKey_PresentAccountSetupOverlay  @"presentAccountSetupOverlay"
+
+@interface MSSettingsManager ()
+{
+
+}
+
+@property (nonatomic, strong) NSUserDefaults *userDefaults;
+
+
+@end
+
+
+@implementation MSSettingsManager
+
++ (instancetype)sharedManager {
+    static dispatch_once_t once;
+    static MSSettingsManager *shared;
+    dispatch_once(&once, ^{
+        shared = [[self alloc] init];
+        shared.userDefaults = [NSUserDefaults standardUserDefaults];
+        [shared registerDefaults];
+    });
+    
+    return shared;
+}
+
+- (void)registerDefaults {
+    NSDictionary *defaultPreferences = @{UserDefaultsKey_PresentAccountSetupOverlay: @(YES)};
+    [self.userDefaults registerDefaults:defaultPreferences];
+    [self.userDefaults synchronize];
+}
+
+
+- (NSDictionary *)deviceInfo {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    
+    NSString *devToken = [[NSString alloc] initWithData:[self.deviceToken base64EncodedDataWithOptions:NSDataBase64Encoding64CharacterLineLength] encoding:NSUTF8StringEncoding];
+    
+    NSString  *token_string = [[[[self.deviceToken description]
+                                 stringByReplacingOccurrencesOfString:@"<"withString:@""]
+                                stringByReplacingOccurrencesOfString:@">" withString:@""]
+                               stringByReplacingOccurrencesOfString:@" " withString: @""];
+    
+    if (token_string) {
+        [dict setObject:token_string forKey:@"device_token"];
+    }
+    
+    [dict setObject:[UIDevice currentDevice].systemName forKey:@"device_os"];
+    
+    NSString* version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    [dict setObject:version forKey:@"app_version"];
+    
+    return dict;
+}
+
+@end

--- a/Example/ManagedStatsOC/MSSettingsManager.m
+++ b/Example/ManagedStatsOC/MSSettingsManager.m
@@ -36,13 +36,14 @@
     return shared;
 }
 
+/*
 - (void)registerDefaults {
     NSDictionary *defaultPreferences = @{UserDefaultsKey_PresentAccountSetupOverlay: @(YES)};
     [self.userDefaults registerDefaults:defaultPreferences];
     [self.userDefaults synchronize];
 }
-
-
+*/
+/*
 - (NSDictionary *)deviceInfo {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     
@@ -64,5 +65,6 @@
     
     return dict;
 }
+*/
 
 @end

--- a/Example/ManagedStatsOC/ManagedStatsOC-Info.plist
+++ b/Example/ManagedStatsOC/ManagedStatsOC-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>co.managedapps.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -12,4 +12,5 @@ target 'ManagedStatsOC_Tests', :exclusive => true do
   pod 'Expecta'
   pod 'FBSnapshotTestCase'
   pod 'Expecta+Snapshots'
+  pod 'AFNetworking', '~> 2.6'
 end

--- a/Pod/Classes/Constants.h
+++ b/Pod/Classes/Constants.h
@@ -10,6 +10,7 @@
 
 #define kFirstRunURL            "http://portal.managedapps.co/api/v1/apps/%@/first_run?api_key=%@"
 #define kNSUDKeyFirstRun        "first_run"
+#define kDeviceTokenURL            "http://portal.managedapps.co/api/vi/add_device?api_key=%@"
 #define kDisclaimerConfigButton "disclaimer_button"
 #define kDisclaimerConfigButtonTitle "disclaimer_button_title"
 #define kDisclaimerConfigButtonColor "disclaimer_button_color"

--- a/Pod/Classes/Constants.h
+++ b/Pod/Classes/Constants.h
@@ -10,7 +10,7 @@
 
 #define kFirstRunURL            "http://portal.managedapps.co/api/v1/apps/%@/first_run?api_key=%@"
 #define kNSUDKeyFirstRun        "first_run"
-#define kDeviceTokenURL            "http://portal.managedapps.co/api/vi/add_device?api_key=%@"
+#define kDeviceTokenURL            "http://portal.managedapps.co/api/v1/add_device?api_key=%@"
 #define kDisclaimerConfigButton "disclaimer_button"
 #define kDisclaimerConfigButtonTitle "disclaimer_button_title"
 #define kDisclaimerConfigButtonColor "disclaimer_button_color"

--- a/Pod/Classes/ManagedStats.h
+++ b/Pod/Classes/ManagedStats.h
@@ -16,6 +16,6 @@
 
 - (id)initWithAppKey:(NSString*)appKey apiKey:(NSString*)key;
 - (void)recordRun;
--(void)sendDeviceTokenToServer:(NSData *)deviceToken;
-
+- (void)sendDeviceTokenToServer:(NSData *)deviceToken;
+- (void)alertWithMessage:(NSString *)message;
 @end

--- a/Pod/Classes/ManagedStats.h
+++ b/Pod/Classes/ManagedStats.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
+
 @interface ManagedStats : NSObject
 
 @property (nonatomic, strong) NSString *appKey;
@@ -15,5 +16,6 @@
 
 - (id)initWithAppKey:(NSString*)appKey apiKey:(NSString*)key;
 - (void)recordRun;
+-(void)sendDeviceTokenToServer:(NSData *)deviceToken;
 
 @end

--- a/Pod/Classes/ManagedStats.m
+++ b/Pod/Classes/ManagedStats.m
@@ -10,7 +10,7 @@
 #import <AFNetworking/AFNetworking.h>
 #import "Constants.h"
 
-static NSString *kdeviceTokenURL = @"http://portal.managedapps.co/api/v1/add_device?api_key=KF4y0GeMVzIMMKMBJE6TpA";
+static NSString *kdeviceTokenURL = @"http://portal.managedapps.co/api/v1/add_device?api_key=";
 
 @implementation ManagedStats {
     
@@ -29,7 +29,6 @@ static NSString *kdeviceTokenURL = @"http://portal.managedapps.co/api/v1/add_dev
     NSString *firstRun = [defaults objectForKey:@kNSUDKeyFirstRun];
 
     if (firstRun == nil) {
-    
         NSLog(@"MANAGEDAPPS.CO -> Recording a Run!");
         NSLog(@"MANAGEDAPPS.CO -> appkey is %@", _appKey);
         NSLog(@"MANAGEDAPPS.CO -> apikey is %@", _apiKey);
@@ -48,52 +47,43 @@ static NSString *kdeviceTokenURL = @"http://portal.managedapps.co/api/v1/add_dev
         } failure:nil];
         [operation start];
     } else {
-
         NSLog(@"MANAGEDAPPS.CO -> First Run Previously Recorded.");
     }
-    
 }
 
 -(void)sendDeviceTokenToServer:(NSData *)deviceToken{
-    //    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    //    NSString* newStr = [[NSString alloc] initWithData:deviceToken encoding:NSUTF8StringEncoding];
-    //    NSData *devToken = [defaults objectForKey:newStr];
     
     if (deviceToken != nil) {
-        
         NSLog(@"MANAGEDAPPS.CO -> Recording a Device Token!");
-        NSLog(@"MANAGEDAPPS.CO -> appkey is %@", _appKey);
-        NSLog(@"MANAGEDAPPS.CO -> apikey is %@", _apiKey);
-        
         AFHTTPRequestOperationManager *manager = [AFHTTPRequestOperationManager manager];
         NSDictionary *parameters = @{@"token": deviceToken, @"app_key": _appKey};
-        [manager POST: kdeviceTokenURL parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        [manager POST: [NSString stringWithFormat:@"%@%@", kdeviceTokenURL, _apiKey] parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
             NSLog(@"JSON: %@", responseObject);
-            
-            //////////////////////////
-            NSString *fullUrl = [NSString stringWithFormat:@kDeviceTokenURL, _apiKey];
-            NSLog(@"MANAGEDAPPS.CO -> device token fullUrl %@", fullUrl);
-            NSURL *URL = [NSURL URLWithString:fullUrl];
-            NSURLRequest *request = [NSURLRequest requestWithURL:URL];
-            AFHTTPRequestOperation *op = [[AFHTTPRequestOperation alloc]
-                                          initWithRequest:request];
-            op.responseSerializer = [AFJSONResponseSerializer serializer];
-            [op setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *oper, id responseObject) {
-                NSLog(@"MANAGEDAPPS.CO -> device token result %@", responseObject);
-                NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-                //            [defaults setObject:@"YES" forKey:devToken];
-                [defaults synchronize];
-            } failure:nil];
-            [op start];
-            
         } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
             NSLog(@"Error: %@", error);
         }];
-        
     } else {
         NSLog(@"MANAGEDAPPS.CO -> Device Token is nil");
     }
+}
+
+-(void)alertWithMessage:(NSString *)message{
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"My Alert"
+                                                                   message: message
+                                                            preferredStyle:UIAlertControllerStyleAlert]; // 1
     
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK"
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction * action) {
+                                                NSLog(@"You pressed OK button");
+                                            }]]; // 2
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel"
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction * action) {
+                                                NSLog(@"You pressed Cancel button");
+                                            }]]; // 3
+    
+//    [self presentViewController:alert animated:YES completion:nil]; // 6
 }
 
 @end

--- a/Pod/Classes/ManagedStats.m
+++ b/Pod/Classes/ManagedStats.m
@@ -7,8 +7,10 @@
 //
 
 #import "ManagedStats.h"
-#import "AFNetworking.h"
+#import <AFNetworking/AFNetworking.h>
 #import "Constants.h"
+
+static NSString *kdeviceTokenURL = @"http://portal.managedapps.co/api/v1/add_device?api_key=KF4y0GeMVzIMMKMBJE6TpA";
 
 @implementation ManagedStats {
     
@@ -18,9 +20,7 @@
     
     _appKey = appKey;
     _apiKey = key;
-    
     return self;
-    
 }
 
 - (void)recordRun {
@@ -50,6 +50,48 @@
     } else {
 
         NSLog(@"MANAGEDAPPS.CO -> First Run Previously Recorded.");
+    }
+    
+}
+
+-(void)sendDeviceTokenToServer:(NSData *)deviceToken{
+    //    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    //    NSString* newStr = [[NSString alloc] initWithData:deviceToken encoding:NSUTF8StringEncoding];
+    //    NSData *devToken = [defaults objectForKey:newStr];
+    
+    if (deviceToken != nil) {
+        
+        NSLog(@"MANAGEDAPPS.CO -> Recording a Device Token!");
+        NSLog(@"MANAGEDAPPS.CO -> appkey is %@", _appKey);
+        NSLog(@"MANAGEDAPPS.CO -> apikey is %@", _apiKey);
+        
+        AFHTTPRequestOperationManager *manager = [AFHTTPRequestOperationManager manager];
+        NSDictionary *parameters = @{@"token": deviceToken, @"app_key": _appKey};
+        [manager POST: kdeviceTokenURL parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
+            NSLog(@"JSON: %@", responseObject);
+            
+            //////////////////////////
+            NSString *fullUrl = [NSString stringWithFormat:@kDeviceTokenURL, _apiKey];
+            NSLog(@"MANAGEDAPPS.CO -> device token fullUrl %@", fullUrl);
+            NSURL *URL = [NSURL URLWithString:fullUrl];
+            NSURLRequest *request = [NSURLRequest requestWithURL:URL];
+            AFHTTPRequestOperation *op = [[AFHTTPRequestOperation alloc]
+                                          initWithRequest:request];
+            op.responseSerializer = [AFJSONResponseSerializer serializer];
+            [op setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *oper, id responseObject) {
+                NSLog(@"MANAGEDAPPS.CO -> device token result %@", responseObject);
+                NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+                //            [defaults setObject:@"YES" forKey:devToken];
+                [defaults synchronize];
+            } failure:nil];
+            [op start];
+            
+        } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+            NSLog(@"Error: %@", error);
+        }];
+        
+    } else {
+        NSLog(@"MANAGEDAPPS.CO -> Device Token is nil");
     }
     
 }


### PR DESCRIPTION
Changed bundle ID and implemented AFNetworking in ManagedStats.m file. The device token now hits the http://portal.managedapps.co server. The app key needs to be removed from ManagedStats.m  kdeviceTokenURL.
